### PR TITLE
feat LevelFlagNoBracket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/src/Async.rs
+++ b/src/Async.rs
@@ -373,6 +373,39 @@ impl Log {
         }
         self
     }
+    pub fn set_level_from_env(&self) -> &Self {
+        if let Ok(v) = std::env::var("LOG_LEVEL") {
+            match v.to_lowercase().as_str() {
+                "trace" => {
+                    unsafe {
+                        asynclog.set_level(LEVEL::Trace);
+                    }
+                }
+                "debug" => {
+                    unsafe {
+                        asynclog.set_level(LEVEL::Debug);
+                    }
+                }
+                "info" => {
+                    unsafe {
+                        asynclog.set_level(LEVEL::Info);
+                    }
+                }
+                "warn" => {
+                    unsafe {
+                        asynclog.set_level(LEVEL::Warn);
+                    }
+                }
+                "error" => {
+                    unsafe {
+                        asynclog.set_level(LEVEL::Error);
+                    }
+                }
+                _ => {}
+            }
+        }
+        self
+    }
 
     pub fn set_console(&self, console: bool) -> &Self {
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@ pub mod Format {
     pub const LongFileName: u8 = 8;
     pub const ShortFileName: u8 = 16;
     pub const LevelFlag: u8 = 32;
+    pub const LevelFlagNoBracket: u8 = 64;
 }
 
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
@@ -338,6 +339,16 @@ fn log_fmt(fmat: u8, formatter: &str, level: LEVEL, filename: &str, line: u32, m
             LEVEL::Warn => "[WARN]",
             LEVEL::Error => "[ERROR]",
             LEVEL::Fatal => "[FATAL]",
+            LEVEL::Off => "",
+        };
+    } else if fmat & Format::LevelFlagNoBracket != 0 {
+        levelflag = match level {
+            LEVEL::Trace => "TRACE",
+            LEVEL::Debug => "DEBUG",
+            LEVEL::Info => "INFO",
+            LEVEL::Warn => "WARN",
+            LEVEL::Error => "ERROR",
+            LEVEL::Fatal => "FATAL",
             LEVEL::Off => "",
         };
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -378,6 +378,40 @@ impl Log {
         self
     }
 
+    pub fn set_level_from_env(&self) -> &Self {
+        if let Ok(v) = std::env::var("LOG_LEVEL") {
+            match v.to_lowercase().as_str() {
+                "trace" => {
+                    unsafe {
+                        synclog.set_level(LEVEL::Trace);
+                    }
+                }
+                "debug" => {
+                    unsafe {
+                        synclog.set_level(LEVEL::Debug);
+                    }
+                }
+                "info" => {
+                    unsafe {
+                        synclog.set_level(LEVEL::Info);
+                    }
+                }
+                "warn" => {
+                    unsafe {
+                        synclog.set_level(LEVEL::Warn);
+                    }
+                }
+                "error" => {
+                    unsafe {
+                        synclog.set_level(LEVEL::Error);
+                    }
+                }
+                _ => {}
+            }
+        }
+        self
+    }
+
     pub fn set_console(&self, console: bool) -> &Self {
         unsafe {
             synclog.set_console(console);

--- a/tests/test_0210.rs
+++ b/tests/test_0210.rs
@@ -67,6 +67,7 @@ mod module4 {
 #[tokio::test]
 async fn testasyncmod() {
     tklog::ASYNC_LOG.set_mod_option("test_0210::module3::*", LogOption { level: None, format: None, formatter: None, console: Some(true), fileoption: Some(Box::new(FileTimeMode::new("asyncmodule2.log", tklog::MODE::DAY, 0, true))) }).await;
+    tklog::ASYNC_LOG.set_mod_option("test_0210::module4", LogOption { level: None, format: None, formatter: None, console: Some(true), fileoption: Some(Box::new(FileTimeMode::new("asyncmodule2.log", tklog::MODE::DAY, 0, true))) }).await;
     module3::testmod().await;
     module3::m3::testmod().await;
     module3::m4::testmod().await;


### PR DESCRIPTION
添加 LevelFlagNoBracket 。LevelFlag 方括号对自定义格式限制太大。我一直用的格式如下：
```
[2024-10-16 23:59:31.968747 DEBUG] Publish. Topic = zra/data, Pkid = 0, Payload Size = 200
[2024-10-16 23:59:32.169537 INFO] Publishing 200 bytes
[2024-10-16 23:59:32.169853 DEBUG] Publish. Topic = zra/data, Pkid = 0, Payload Size = 200
[2024-10-16 23:59:32.357520 INFO] Received 1134 bytes
[2024-10-16 23:59:32.371241 INFO] Publishing 200 bytes
[2024-10-16 23:59:32.371427 DEBUG] Publish. Topic = zra/data, Pkid = 0, Payload Size = 200
[2024-10-16 23:59:32.574099 INFO] Publishing 200 bytes
[2024-10-16 23:59:32.574424 DEBUG] Publish. Topic = zra/data, Pkid = 0, Payload Size = 200
```
